### PR TITLE
Reduce the number of generations of twin error strings

### DIFF
--- a/lib/cdigits/luhn/random_table.rb
+++ b/lib/cdigits/luhn/random_table.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Cdigits
+  module Luhn
+    class RandomTable
+      attr_accessor :previsous
+
+      def initialize(modulus:)
+        @modulus = modulus
+        @previsous = nil
+      end
+
+      # pick from number table exclude 0
+      # @return [Integer]
+      def pick_non_zero
+        pick(exclude: [0])
+      end
+
+      # pick from number table
+      # @param exclude [Array<Intger>] exclude numbers
+      # @return [Integer]
+      def pick(exclude: [])
+        table(exclude).sample
+      end
+
+      private
+
+      def numbers
+        @numbers ||= (0..max).to_a.freeze
+      end
+
+      def max
+        @modulus - 1
+      end
+
+      # @return [Array<Integer>]
+      def table(exclude)
+        exclude << next_numbers_to_avoid[@previsous]
+        table = numbers - exclude.compact
+        table.empty? ? numbers : table
+      end
+
+      def next_numbers_to_avoid
+        @next_numbers_to_avoid ||= build_next_numbers_to_avoid
+      end
+
+      def build_next_numbers_to_avoid
+        defaults = { 0 => max, max => 0 }
+        return defaults unless occure_twin_error?
+
+        defaults.merge(twin_error_values)
+      end
+
+      # @note
+      #   modulus = 10
+      #   twin | doubled value
+      #   ---- | -------------
+      #   00 | 0
+      #   11 | 3
+      #   22 | 6
+      #   33 | 9
+      #   44 | 12
+      #   55 | 6
+      #   66 | 9
+      #   77 | 12
+      #   88 | 15
+      #   99 | 18
+      # @example
+      #   # when @modulus = 10
+      #   twin_error_values # => { 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6, 7 => 7 }
+      # @return [Hash]
+      def twin_error_values
+        size = (max / 3).to_i
+        start = (@modulus / 2.0).ceil - size
+        stop = start + size * 2 - 1
+        values = (start..stop).to_a
+        values.zip(values).to_h
+      end
+
+      def occure_twin_error?
+        (max % 3).zero?
+      end
+    end
+  end
+end

--- a/lib/cdigits/luhn/store.rb
+++ b/lib/cdigits/luhn/store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'securerandom'
+require 'cdigits/luhn/random_table'
 
 module Cdigits
   module Luhn
@@ -34,19 +34,21 @@ module Cdigits
       # Append random non-zero number to digits array
       # @return [Integer] appended value
       def append_non_zero_number
-        append random_number(@modulus - 1) + 1
+        append table.pick_non_zero
       end
 
       # Append random number to digits array
       # @return [Integer] appended value
       def append_number
-        append random_number(@modulus)
+        append table.pick
       end
 
       # Append passed value to digits array
-      # @param [Integer] value
+      # @param value [Integer]
+      # @param freeze [Boolean]
       # @return [Integer] appended value
       def append(value)
+        table.previsous = value
         @digits << value
         value
       end
@@ -62,8 +64,8 @@ module Cdigits
 
       private
 
-      def random_number(num)
-        ::SecureRandom.random_number(num)
+      def table
+        @table ||= ::Cdigits::Luhn::RandomTable.new(modulus: @modulus)
       end
 
       def calculate_check_digit(value, odd)

--- a/spec/cdigits/luhn/placeholder_spec.rb
+++ b/spec/cdigits/luhn/placeholder_spec.rb
@@ -11,18 +11,7 @@ RSpec.describe Cdigits::Luhn::Placeholder do
     context 'when characters: numbers' do
       let(:characters) { Cdigits::Luhn::NUMBER_CHARACTERS }
 
-      context 'placeholder: +###?' do
-        let(:placeholder) { '+###?' }
-
-        before do
-          allow(SecureRandom).to receive(:random_number).with(9).and_return(0)
-          allow(SecureRandom).to receive(:random_number).with(10).and_return(4, 5, 6)
-        end
-
-        it { is_expected.to eq '14563' }
-      end
-
-      context 'when placeholder is "5?-202001"' do
+      context 'when placeholder is "AB5?-202001"' do
         let(:placeholder) { 'AB5?-20200109' }
 
         it { is_expected.to eq 'AB51-20200109' }
@@ -32,13 +21,8 @@ RSpec.describe Cdigits::Luhn::Placeholder do
     context 'when characters: ["A", "B", "C", "D", "E", "F"]' do
       let(:characters) { %w[A B C D E F] }
 
-      context 'placeholder: +######?' do
-        let(:placeholder) { '+######?' }
-
-        before do
-          allow(SecureRandom).to receive(:random_number).with(5).and_return(0)
-          allow(SecureRandom).to receive(:random_number).with(6).and_return(0, 1, 2, 3, 4, 5)
-        end
+      context 'when placeholder is "BABCDEF?"' do
+        let(:placeholder) { 'BABCDEF?' }
 
         it { is_expected.to eq 'BABCDEFC' }
       end

--- a/spec/cdigits/luhn/random_table_spec.rb
+++ b/spec/cdigits/luhn/random_table_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cdigits::Luhn::RandomTable do
+  let(:random_table) { described_class.new(modulus: modulus) }
+
+  describe '#pick_non_zero' do
+    subject { random_table.pick_non_zero }
+    let(:modulus) { 2 }
+
+    it { is_expected.to eq 1 }
+  end
+
+  describe '#pick' do
+    subject { random_table.pick(exclude: exclude) }
+    let(:modulus) { 10 }
+
+    context 'exclude: [0..8]' do
+      let(:exclude) { (0..8).to_a }
+
+      it { is_expected.to eq 9 }
+    end
+  end
+
+  describe '#table' do
+    subject(:table) { random_table.send(:table, exclude) }
+
+    let(:exclude) { [] }
+
+    context 'when modulus: 9' do
+      let(:modulus) { 9 }
+      {
+        nil => (0..8).to_a,
+        0 => (0..7).to_a,
+        1 => (0..8).to_a,
+        2 => (0..8).to_a,
+        3 => (0..8).to_a,
+        4 => (0..8).to_a,
+        5 => (0..8).to_a,
+        6 => (0..8).to_a,
+        7 => (0..8).to_a,
+        8 => (1..8).to_a
+      }.each do |previsous, expected|
+        it "When previsous is #{previsous}, should #{expected}" do
+          random_table.previsous = previsous
+          expect(table).to eq expected
+        end
+      end
+    end
+
+    context 'when modulus: 10' do
+      let(:modulus) { 10 }
+      {
+        nil => (0..9).to_a,
+        0 => (0..8).to_a,
+        1 => (0..9).to_a,
+        2 => (0..9).to_a - [2],
+        3 => (0..9).to_a - [3],
+        4 => (0..9).to_a - [4],
+        5 => (0..9).to_a - [5],
+        6 => (0..9).to_a - [6],
+        7 => (0..9).to_a - [7],
+        8 => (0..9).to_a,
+        9 => (1..9).to_a
+      }.each do |previsous, expected|
+        it "When previsous is #{previsous}, should #{expected}" do
+          random_table.previsous = previsous
+          expect(table).to eq expected
+        end
+      end
+    end
+
+    context 'when modulus: 13' do
+      let(:modulus) { 13 }
+      {
+        nil => (0..12).to_a,
+        0 => (0..11).to_a, # doubled: 0
+        1 => (0..12).to_a, # doubled: 3
+        2 => (0..12).to_a, # doubled: 6
+        3 => (0..12).to_a - [3], # doubled: 9
+        4 => (0..12).to_a - [4], # doubled: 12
+        5 => (0..12).to_a - [5], # doubled: 15
+        6 => (0..12).to_a - [6], # doubled: 18
+        7 => (0..12).to_a - [7], # doubled: 9
+        8 => (0..12).to_a - [8], # doubled: 12
+        9 => (0..12).to_a - [9], # doubled: 15
+        10 => (0..12).to_a - [10], # doubled: 18
+        11 => (0..12).to_a, # doubled: 21
+        12 => (1..12).to_a # doubled: 24
+      }.each do |previsous, expected|
+        it "When previsous is #{previsous}, should #{expected}" do
+          random_table.previsous = previsous
+          expect(table).to eq expected
+        end
+      end
+    end
+
+    context 'when modulus: 16' do
+      let(:modulus) { 16 }
+      {
+        nil => (0..15).to_a,
+        0 => (0..14).to_a, # doubled: 0
+        1 => (0..15).to_a, # doubled: 3
+        2 => (0..15).to_a, # doubled: 6
+        3 => (0..15).to_a - [3], # doubled: 9
+        4 => (0..15).to_a - [4], # doubled: 12
+        5 => (0..15).to_a - [5], # doubled: 15
+        6 => (0..15).to_a - [6], # doubled: 18
+        7 => (0..15).to_a - [7], # doubled: 21
+        8 => (0..15).to_a - [8], # doubled: 9
+        9 => (0..15).to_a - [9], # doubled: 12
+        10 => (0..15).to_a - [10], # doubled: 15
+        11 => (0..15).to_a - [11], # doubled: 18
+        12 => (0..15).to_a - [12], # doubled: 21
+        13 => (0..15).to_a, # doubled: 24
+        14 => (0..15).to_a, # doubled: 27
+        15 => (1..15).to_a # doubled: 30
+      }.each do |previsous, expected|
+        it "When previsous is #{previsous}, should #{expected}" do
+          random_table.previsous = previsous
+          expect(table).to eq expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What's twin error?

if the valid sequence is `22`,  no error can be detected even if `55` is entered

sequence | doubled value
---------- | --------------
00 | 0
11 | 3
22 | 6
33 | 9
44 | 12
55 | 6
66 | 9
77 | 12
88 | 15
99 | 18

This error occurs when modulus is `(modulus-1)% 3 == 0`

## Before

```rb
avoid = /(09|22|33|44|55|66|77|90)/
values = []
10_000.times do
  value = Cdigits::Luhn.number
  values << value if value.match?(avoid)
end
values.size
# => 5193
values.take(10)
# => ["2520966827", "6929043328", "3452533999", "4352218509", "4128096916", "3526609494", "6394633496", "6653960234", "9605337295", "9938322949"]
```

## After

```rb
avoid = /(09|22|33|44|55|66|77|90)/
values = []
10_000.times do
  value = Cdigits::Luhn.number
  values << value if value.match?(avoid)
end
values.size
# => 735
values.take(10)
# => ["9814137866", "3741768109", "6878518122", "3587863477", "1706163977", "9994219922", "4167581455", "5250656922", "1193648233", "3041872544"]
```